### PR TITLE
[FEAT]: Play Media URIs Directly, Addressing Uri Expiry Issue

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,10 +26,10 @@ android {
     namespace = "com.prime.media"
     defaultConfig {
         applicationId = "com.prime.player"
-        minSdk = 21
+        minSdk = 27
         targetSdk = 34
         versionCode = 54
-        versionName = "2.5.0"
+        versionName = "2.5.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
         //Load secrets into BuildConfig

--- a/app/src/main/java/com/prime/media/console/Console.kt
+++ b/app/src/main/java/com/prime/media/console/Console.kt
@@ -464,7 +464,7 @@ private fun Vertical(
             content = {
                 val mills = state.sleepAfterMills
                 if (mills == -1L)
-                    return@IconButton Icon(imageVector = Icons.Outlined.Timer, contentDescription = null)
+                    return@IconButton Icon(imageVector = Icons.Outlined.Timer, contentDescription = null,  tint = onColor)
                 Label(
                     text = formatElapsedTime(mills/1000L),
                     style = Material.typography.caption2,

--- a/app/src/main/java/com/prime/media/dialog/PlayingQueue.kt
+++ b/app/src/main/java/com/prime/media/dialog/PlayingQueue.kt
@@ -59,6 +59,7 @@ import com.prime.media.core.playback.mediaUri
 import com.prime.media.core.playback.subtitle
 import com.prime.media.core.playback.title
 import com.prime.media.small2
+import com.prime.media.surfaceColorAtElevation
 import com.primex.material2.Dialog
 import com.primex.material2.IconButton
 import com.primex.material2.Label
@@ -142,7 +143,7 @@ private fun TopAppBar(
 ) {
     TopAppBar(
         title = { Label(text = stringResource(R.string.playing_queue), style =  Material.typography.body2, fontWeight = FontWeight.Bold) },
-        backgroundColor = Material.colors.surface,
+        backgroundColor = Material.colors.surfaceColorAtElevation(1.dp),
         contentColor = Material.colors.onSurface,
         elevation = 0.dp,
         modifier = modifier,
@@ -307,6 +308,7 @@ fun PlayingQueue(
                         modifier = Modifier.padding(it)
                     )
                 },
+                backgroundColor = Material.colors.surface,
             )
         }
     )

--- a/app/src/main/java/com/prime/media/impl/MediaMetaDataArtFetcher.kt
+++ b/app/src/main/java/com/prime/media/impl/MediaMetaDataArtFetcher.kt
@@ -1,0 +1,151 @@
+package com.prime.media.impl
+
+import android.content.ContentUris
+import android.graphics.BitmapFactory
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.core.graphics.drawable.toDrawable
+import coil.decode.DataSource
+import coil.decode.DecodeUtils
+import coil.fetch.DrawableResult
+import coil.fetch.FetchResult
+import coil.fetch.Fetcher
+import coil.request.Options
+import coil.size.Dimension
+import com.prime.media.R
+import com.prime.media.core.db.query2
+
+private const val TAG = "MediaMetaDataArtFetcher"
+
+/**
+ *  FixMe: Find Proper way to implement this thing.
+ *
+ * The default fetch result containing a default drawable to be used when there is an error
+ * or failure in retrieving the actual image.
+ * This is generated lazily.
+
+ */
+private var DEFAULT_RESULT: FetchResult? = null
+
+// TODO: Move this class to its proper place.
+/**
+ * This class is responsible for fetching real album art from media using the [MediaMetadataRetriever].
+ *
+ * It should be used with caution, as it consumes significant system resources. Ensure that it is only called
+ * with the user's explicit consent.
+ *
+ * The [data] property in this class represents the URI of the album art. To minimize project-wide changes,
+ * we use this property as-is. Internally, it retrieves the actual data column from the MediaStore audio database
+ * using the [MediaMetadataRetriever] to fetch the artwork. If the artwork is null, it returns a default art
+ * instead of null. This approach is taken to prevent Coil (an image loading library) from loading artwork
+ * from its built-in Content URI component, which may lead to incorrect artwork retrieval from the MediaStore.
+ *
+ * @param data The URI representing the album art. Use with caution and ensure user consent.
+ * @param options The options for fetching the album art.
+ */
+class MediaMetaDataArtFetcher(
+    private val data: Uri,
+    private val options: Options
+) : Fetcher {
+    override suspend fun fetch(): FetchResult {
+        // Initialize the default fetcher only once.
+        // But why is this required, you might wonder?
+        // The necessity arises from the fact that if we simply return the default implementation
+        // of UriFetcher provided by Coil, it may return incorrect or invalid artwork for certain results.
+        // So, to ensure consistent and reliable default artwork behavior, we set up a DrawableResult
+        // representing the default artwork. This DrawableResult is then used as the fallback
+        // when fetching artwork for a particular result.
+        if (DEFAULT_RESULT == null) {
+            DEFAULT_RESULT = DrawableResult(
+                options.context.getDrawable(R.drawable.default_art)!!,
+                isSampled = false,
+                dataSource = DataSource.MEMORY
+            )
+        }
+
+        // The 'data[uri]' we receive above still represents the album art URI.
+        // However, this URI format is not directly compatible with the MediaMetadataRetriever.
+        // To work with MediaMetadataRetriever, we need to extract the album ID from this URI.
+        // Once we have the album ID, we can query the MediaStore for the '_data' column
+        // associated with that album ID. This should give us the unique '_data' field
+        // pointing to the embedded image data.
+        // We can then initialize the MediaMetadataRetriever and use it to extract the embedded
+        // image data from the '_data' column of the audio record associated with this album art URI.
+        // Why this? Because we do not want to make any changes to the project, hence this approach
+        // allows us to work with the existing structure without significant modifications.
+        val resolver = options.context.contentResolver
+        val projection = arrayOf(MediaStore.Audio.Media.DATA)
+        val selection = "${MediaStore.Audio.Media.ALBUM_ID} == ${ContentUris.parseId(data)}"
+        val parent = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+
+        // Query the data using the resolver with specified parameters.
+        val data = resolver.query2(parent, projection, selection, null, limit = 1).use {
+            // This section of code handles an unexpected scenario where the retrieval of album art data
+            // encounters an issue. If this situation occurs, we should return the default artwork instead.
+            // This is a fallback mechanism to ensure that even in the face of errors or missing data,
+            // we can provide a default result.
+            if (it == null || !it.moveToFirst())
+                return DEFAULT_RESULT!!
+            // At this point in the code, we expect that the path should not be null.
+            // However, if somehow it is null, we again fall back to the default result.
+            it.getString(0) ?: return DEFAULT_RESULT!!
+        }
+
+        // Initialize a MediaMetadataRetriever to work with the retrieved data.
+        return MediaMetadataRetriever().use { retriever ->
+            retriever.setDataSource(data)
+            // fallback to default if null
+            val bytes = retriever.embeddedPicture ?: return DEFAULT_RESULT!!
+            var isSampled: Boolean
+            val bitmap = BitmapFactory.Options().let {
+                // Set inJustDecodeBounds to true to determine the image dimensions without loading it.
+                it.inJustDecodeBounds = true
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, it)
+
+                // Initialize the destination size; fallback to the default size if null.
+                val width = (options.size.width as? Dimension.Pixels)?.px ?: it.outWidth
+                val height = (options.size.height as? Dimension.Pixels)?.px ?: it.outHeight
+
+                // Determine if the image needs to be sampled based on its original dimensions.
+                isSampled = if (it.outWidth > 0 && it.outHeight > 0) {
+
+                    // Calculate the size multiplier and check if it's less than 1.0.
+                    // If it's less than 1.0, consider the image as sampled.
+                    DecodeUtils.computeSizeMultiplier(
+                        srcWidth = it.outWidth,
+                        srcHeight = it.outHeight,
+                        dstWidth = width,
+                        dstHeight = height,
+                        scale = options.scale
+                    ) < 1.0
+                } else {
+
+                    // We were unable to determine the original size of the image.
+                    // Assume it is sampled to avoid potential issues.
+                    true
+                }
+                it.inSampleSize = DecodeUtils.calculateInSampleSize(
+                    it.outWidth,
+                    it.outHeight,
+                    width,
+                    height,
+                    options.scale
+                )
+
+                // Calculate the inSampleSize for bitmap decoding.
+                it.inJustDecodeBounds = false
+
+                // Decode the bitmap from the provided byte array.
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, it)
+            }
+
+            DrawableResult(
+                drawable = bitmap.toDrawable(options.context.resources),
+                isSampled = isSampled,
+                dataSource = DataSource.DISK
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/prime/media/library/Library.kt
+++ b/app/src/main/java/com/prime/media/library/Library.kt
@@ -89,6 +89,7 @@ import com.prime.media.onOverlay
 import com.prime.media.overlay
 import com.prime.media.settings.Settings
 import com.prime.media.small2
+import com.prime.media.surfaceColorAtElevation
 import com.primex.core.gradient
 import com.primex.core.padding
 import com.primex.core.rememberState
@@ -193,12 +194,12 @@ private fun TopBar(modifier: Modifier = Modifier) {
         val provider = LocalSystemFacade.current
         TopAppBar(
             modifier = Modifier
-                .background(Material.colors.overlay)
+                .background(Material.colors.surfaceColorAtElevation(2.dp))
                 .requiredHeight(TOP_BAR_HEIGHT)
                 .then(modifier),
             elevation = 0.dp,
             backgroundColor = Color.Transparent,
-            contentColor = Material.colors.onOverlay,
+            contentColor = Material.colors.onSurface,
             // navigation icon pointing to the about section of the app.
             // TODO - Add navigation to about us in future.
             navigationIcon = {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,7 +235,8 @@
     <!--Fetch_artwork_from_MediaStore-->
     <string name="pref_fetch_artwork_from_mediastore">Fetch artwork from MediaStore</string>
     <string name="pref_fetch_artwork_from_mediastore_summery">
-        Faster artwork loading time, but can show incorrect artwork
+         Faster artwork loading times, but there is a possibility of displaying incorrect artwork.\n
+        Changing this setting requires <i>restarting</i> the app.
     </string>
     <!--Enable Trash can-->
     <string name="pref_enable_trash_can">Enable trash can</string>


### PR DESCRIPTION
- This commit updates the app to directly play media URIs received through intents, ensuring that all URIs are played correctly without having to search for real URIs in the MediaStore. However, it introduces a challenge of URI expiry after app restarts, which will require additional handling to remove expired URIs during state restoration. This commit fixes #26 github issue.

[Feat]: Introduce MediaMetaDataArtFactory for Optional Album Artwork Retrieval

This commit adds a new component, `MediaMetaDataArtFactory`, responsible for handling the retrieval of album artwork using MediaMetadataRetriever. The feature is designed to be optional and will only be used when the user chooses to enable it, respecting user preferences for album artwork retrieval methods.

- Added `MediaMetaDataArtFactory` component
- Conditionally create `MediaMetaDataArtFetcher` based on Uri and user preferences

[UPDATE] Bumped minSDK version to 8.0
- The minimum Android version has been increased to 8.0 to support various APIs like soft navbar light/dark status bar, and larger screen sizes.
- Fixed the color issue with the Timer button in dark mode.
- The header of Library.kt now uses the surfaceColorAt function as its background.
- Changes have been made to the color of topbar and background of PlayingQueue to resolve accessibility issues in dark mode.