### PR TITLE
[FEAT]: Added Equalizer Audio Fx in Playback.kt, Added AudioFx UI and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <h6>An Open-Source Media Player App for all your needs!</h6>
 
 <!--Info-->
-[![Release](https://img.shields.io/github/v/release/iZakirSheikh/Audiofy2)](https://play.google.com/store/apps/details?id=com.prime.player)
+[![Release](https://img.shields.io/github/v/release/iZakirSheikh/Audiofy2)](https://github.com/iZakirSheikh/Audiofy/releases)
 [![Playstore](https://img.shields.io/endpoint?color=crimson&logo=google-play&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.prime.player%26l%3DGoogle%2520Play%26m%3Dv%24version)](https://play.google.com/store/apps/details?id=com.prime.player)
 [![Google Play Installs](https://img.shields.io/endpoint?color=forestgreen&logo=google-play&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.prime.player%26l%3Ddownloads%26m%3D%24totalinstalls)](https://play.google.com/store/apps/details?id=com.prime.player)
 [![Google Play Rating](https://img.shields.io/endpoint?color=forestgreen&logo=google-play&url=https%3A%2F%2Fplay.cuzi.workers.dev%2Fplay%3Fi%3Dcom.prime.player%26l%3Drating%26m%3D%25E2%2598%2585%2520%24rating)](https://play.google.com/store/apps/details?id=com.prime.player)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.prime.player"
         minSdk = 27
         targetSdk = 34
-        versionCode = 55
-        versionName = "2.5.1"
+        versionCode = 56
+        versionName = "2.6.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
         //Load secrets into BuildConfig

--- a/app/src/main/java/com/prime/media/Home.kt
+++ b/app/src/main/java/com/prime/media/Home.kt
@@ -46,6 +46,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.rememberPermissionState
@@ -75,6 +76,8 @@ import com.prime.media.directory.store.FoldersViewModel
 import com.prime.media.directory.store.Genres
 import com.prime.media.directory.store.GenresViewModel
 import com.prime.media.editor.TagEditor
+import com.prime.media.effects.AudioFx
+import com.prime.media.impl.AudioFxViewModel
 import com.prime.media.impl.ConsoleViewModel
 import com.prime.media.impl.LibraryViewModel
 import com.prime.media.impl.SettingsViewModel
@@ -398,6 +401,11 @@ private fun NavGraph(
         composable(TagEditor.route){
             val viewModel = hiltViewModel<TagEditorViewModel>()
             TagEditor(state = viewModel)
+        }
+
+        dialog(AudioFx.route){
+            val viewModel = hiltViewModel<AudioFxViewModel>()
+            AudioFx(state = viewModel)
         }
     }
 }

--- a/app/src/main/java/com/prime/media/console/Console.kt
+++ b/app/src/main/java/com/prime/media/console/Console.kt
@@ -92,6 +92,7 @@ import com.prime.media.core.LongDurationMills
 import com.prime.media.core.MediumDurationMills
 import com.prime.media.core.compose.AnimatedIconButton
 import com.prime.media.core.compose.Image
+import com.prime.media.core.compose.LocalNavController
 import com.prime.media.core.compose.LocalSystemFacade
 import com.prime.media.core.compose.LottieAnimButton
 import com.prime.media.core.compose.LottieAnimation
@@ -102,6 +103,7 @@ import com.prime.media.darkShadowColor
 import com.prime.media.dialog.PlaybackSpeedDialog
 import com.prime.media.dialog.PlayingQueue
 import com.prime.media.dialog.Timer
+import com.prime.media.effects.AudioFx
 import com.prime.media.lightShadowColor
 import com.prime.media.outline
 import com.prime.media.settings.Settings
@@ -335,8 +337,9 @@ private fun Vertical(
             atEnd = !favourite
         )
 
+        val controller = LocalNavController.current
         IconButton(
-            onClick = { facade.launchEqualizer(state.audioSessionId) },
+            onClick = { controller.navigate(AudioFx.route) },
             imageVector = Icons.Outlined.Tune,
             contentDescription = null,
             modifier = Modifier.layoutID(Console.EQUALIZER),

--- a/app/src/main/java/com/prime/media/core/playback/Remote.kt
+++ b/app/src/main/java/com/prime/media/core/playback/Remote.kt
@@ -1,5 +1,6 @@
 package com.prime.media.core.playback
 
+import android.media.audiofx.Equalizer
 import android.net.Uri
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -69,6 +70,11 @@ interface Remote {
      * @return True if media playback is ongoing, false otherwise.
      */
     val isPlaying: Boolean
+
+    /**
+     * @see [Player.getPlayWhenReady]
+     */
+    val playWhenReady: Boolean
 
     /**
      * Gets the current repeat mode for media playback.
@@ -384,4 +390,26 @@ interface Remote {
      *   [Playback.UNINITIALIZED_SLEEP_TIME_MILLIS] to cancel the already one.
      * */
     suspend fun getSleepTimeAt(): Long
+
+    /**
+     * Sets a new equalizer in the [Playback]. If the [eq] parameter is null, the equalizer settings
+     * will be overridden and turned off. Note that after calling this function, the previous equalizer
+     * will be automatically released.
+     *
+     * @param eq The new Equalizer instance to be set, or null to turn off the equalizer.
+     */
+    suspend fun setEqualizer(eq: Equalizer?)
+
+    /**
+     * Constructs a new equalizer based on the settings received through the playback and returns the
+     * new Equalizer instance.
+     *
+     * The equalizer in the playback has its property set to 0. To activate the equalizer, use a value
+     * higher than 0 for the [priority] parameter. If the equalizer in playback is not set up, an
+     * Equalizer with default configuration will be returned.
+     *
+     * @param priority The priority level for the new equalizer. Use a value higher than 0 to activate it.
+     * @return The newly created Equalizer instance.
+     */
+    suspend fun getEqualizer(priority: Int): Equalizer
 }

--- a/app/src/main/java/com/prime/media/effects/AudioFx.kt
+++ b/app/src/main/java/com/prime/media/effects/AudioFx.kt
@@ -1,0 +1,249 @@
+@file:OptIn(ExperimentalMaterialApi::class)
+
+package com.prime.media.effects
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.ChipDefaults
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FilterChip
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.Slider
+import androidx.compose.material.Switch
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.prime.media.Material
+import com.prime.media.R
+import com.prime.media.caption2
+import com.prime.media.core.ContentPadding
+import com.prime.media.core.compose.LocalNavController
+import com.prime.media.small2
+import com.prime.media.surfaceColorAtElevation
+import com.primex.core.rotateTransform
+import com.primex.core.textResource
+import com.primex.material2.Label
+import com.primex.material2.TextButton
+
+private const val TAG = "AudioFx"
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+@NonRestartableComposable
+private fun TopBar(
+    enabled: Boolean,
+    onToggleState: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    androidx.compose.material.TopAppBar(
+        title = {
+            Label(
+                text = textResource(R.string.equalizer),
+                style = Material.typography.body1,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        backgroundColor = Material.colors.surfaceColorAtElevation(1.dp),
+        contentColor = Material.colors.onSurface,
+        modifier = modifier,
+        elevation = 0.dp,
+        actions = {
+            Switch(checked = enabled, onCheckedChange = onToggleState)
+        }
+    )
+}
+
+
+@Composable
+@NonRestartableComposable
+private fun BottomBar(
+    modifier: Modifier = Modifier,
+    onDismissRequest: (apply: Boolean) -> Unit
+) {
+    // Buttons
+    Row(
+        horizontalArrangement = Arrangement.End,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = ContentPadding.normal)
+    ) {
+        // In case it is running; it will stop it.
+        TextButton(
+            label = stringResource(id = R.string.dismiss),
+            onClick = { onDismissRequest(false) }
+        )
+
+        // start the timer.
+        TextButton(
+            label = stringResource(id = R.string.apply),
+            onClick = { onDismissRequest(true) })
+    }
+}
+
+
+@Composable
+private fun Equalizer(
+    fx: AudioFx,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        modifier = modifier
+            .sizeIn(maxHeight = 220.dp)
+            .horizontalScroll(rememberScrollState()),
+    ) {
+        // y - axis
+        Column(
+            verticalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxHeight()
+        ) {
+            CompositionLocalProvider(LocalTextStyle provides Material.typography.caption) {
+                Label(
+                    text = stringResource(
+                        id = R.string.equalizer_scr_abbr_db_suffix_d,
+                        fx.eqBandLevelRange.endInclusive / 1000
+                    )
+                )
+                Label(text = stringResource(id = R.string.equalizer_scr_abbr_db_suffix_d, 0))
+                Label(
+                    text = stringResource(
+                        id = R.string.equalizer_scr_abbr_db_suffix_d,
+                        fx.eqBandLevelRange.start / 1000
+                    )
+                )
+            }
+        }
+
+        // bars
+        repeat(fx.eqNumberOfBands) { band ->
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Slider(
+                    value = fx.eqBandLevels[band],
+                    onValueChange = { fx.setBandLevel(band, it) },
+                    modifier = Modifier
+                        .padding(bottom = ContentPadding.medium)
+                        .weight(1f)
+                        .rotateTransform(false),
+                    valueRange = fx.eqBandLevelRange
+                )
+
+                Label(
+                    text = stringResource(
+                        id = R.string.equalizer_scr_abbr_hz_suffix_d,
+                        fx.getBandCenterFreq(band) / 1000
+                    ),
+                    style = Material.typography.caption2
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@NonRestartableComposable
+fun Preset(
+    label: CharSequence,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    selected: Boolean = false,
+    enabled: Boolean = true,
+    icon: ImageVector? = null,
+) {
+    val color = ChipDefaults.outlinedFilterChipColors(backgroundColor = Color.Transparent)
+    FilterChip(
+        onClick = onClick,
+        colors = color,
+        selected = selected,
+        enabled = enabled,
+        border =
+        BorderStroke(1.dp, Material.colors.primary.copy(ChipDefaults.OutlinedBorderOpacity)),
+        modifier = modifier.padding(ContentPadding.small)
+    ) {
+        Label(
+            text = label,
+            modifier = Modifier.padding(end = ContentPadding.small),
+            style = Material.typography.caption
+        )
+
+        if (icon == null)
+            return@FilterChip
+        Icon(
+            imageVector = icon,
+            contentDescription = label.toString(),
+            modifier = Modifier.size(16.dp)
+        )
+    }
+}
+
+
+@Composable
+@NonRestartableComposable
+fun AudioFx(
+    state: AudioFx
+) {
+    Column(
+        modifier = Modifier
+            .clip(Material.shapes.small2)
+            .background(Material.colors.surface)
+            .fillMaxWidth()
+            .pointerInput(Unit) {}
+    ) {
+        TopBar(state.isEqualizerEnabled, onToggleState = { state.isEqualizerEnabled = it })
+        Row(
+            Modifier
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = ContentPadding.normal, vertical = ContentPadding.medium)
+        ) {
+            val current = state.eqCurrentPreset
+            Preset(
+                label = "Custom",
+                onClick = { state.eqCurrentPreset = -1 },
+                selected = current == -1
+            )
+            state.eqPresets.forEachIndexed { index, s ->
+                Preset(
+                    label = s,
+                    onClick = { state.eqCurrentPreset = index },
+                    selected = current == index
+                )
+            }
+        }
+
+        Equalizer(
+            fx = state,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = ContentPadding.normal, vertical = ContentPadding.medium)
+        )
+
+        val controller = LocalNavController.current
+        BottomBar(
+            onDismissRequest = {
+                if (it)
+                    state.apply()
+                controller.navigateUp()
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/prime/media/effects/ViewState.kt
+++ b/app/src/main/java/com/prime/media/effects/ViewState.kt
@@ -1,0 +1,117 @@
+package com.prime.media.effects
+
+import androidx.compose.runtime.Stable
+
+/**
+ * Interface for controlling the state and settings of the AudioFx screen, specifically for Equalizer settings in Android.
+ *
+ * This interface allows you to manage the state and settings related to the Equalizer in the AudioFx screen.
+ * It provides methods for enabling/disabling, selecting presets, and adjusting band levels.
+ *
+ * @see AudioFx.Companion.direction for usage in [LocalNalController].
+ * @see AudioFx.Companion.route for the route to access AudioFx settings.
+ */
+@Stable
+interface AudioFx {
+
+    companion object {
+        /** Route to access AudioFx settings. */
+        const val route = "audio_fx"
+
+        /**
+         * Get the direction to the AudioFx settings.
+         *
+         * @return The route to AudioFx settings.
+         */
+        fun direction() = route
+
+        const val EFFECT_STATUS_UNSUPPORTED = -1
+        const val EFFECT_STATUS_DISABLED = 0
+        const val EFFECT_STATUS_ENABLED = 1
+        const val EFFECT_STATUS_NO_CONTROL = 2
+    }
+
+    /**
+     * Property for enabling or disabling the Equalizer.
+     */
+    var isEqualizerEnabled: Boolean
+
+    /**
+     * List of supported Equalizer presets.
+     */
+    val eqPresets: List<String>
+
+    /**
+     * Get the number of supported bands in the Equalizer.
+     */
+    val eqNumberOfBands: Int
+
+    /**
+     * Get the number of available Equalizer presets.
+     * This may be greater than the actual default presets of equalizer.
+     */
+    val eqNumPresets: Int
+        get() = eqPresets.size
+
+    /**
+     * Get/Sets the currently selected Equalizer preset.
+     * If no preset is selected, it will return -1, representing the custom preset.
+     *
+     *  Note: The index of the preset to apply. It must be -1 for a custom preset or any value from
+     *  0 to the number of presets.
+     *
+     */
+    var eqCurrentPreset: Int
+
+    /**
+     * List of band levels for the Equalizer.
+     * The size of this list corresponds to the number of bands in the Equalizer.
+     */
+    val eqBandLevels: List<Float>
+
+    /**
+     * Range of band level values for the Equalizer.
+     *
+     * This property represents the valid range of band level values for the Equalizer.
+     * The range is specified as a [ClosedFloatingPointRange].
+     *
+     * @see android.media.audiofx.Equalizer.getBandLevelRange
+     */
+    val eqBandLevelRange: ClosedFloatingPointRange<Float>
+
+    /**
+     * Get the frequency range for a specific Equalizer band.
+     *
+     * @param band The index of the Equalizer band.
+     * @return The frequency range for the specified band as a [ClosedFloatingPointRange].
+     * @see android.media.audiofx.Equalizer.getBandFreqRange
+     */
+    fun getBandFreqRange(band: Int): ClosedFloatingPointRange<Float>
+
+    /**
+     * Set the level of a specific Equalizer band.
+     *
+     * @param band The index of the Equalizer band.
+     * @param level The desired level to set for the band.
+     */
+    fun setBandLevel(band: Int, level: Float)
+
+    /**
+     * Gets the center frequency of a specific equalizer band.
+     *
+     * This function retrieves the center frequency of the equalizer band identified by the [band] parameter.
+     *
+     * @param band The index of the equalizer band for which to retrieve the center frequency.
+     * @return The center frequency of the specified equalizer band in Hertz (Hz).
+     * @see android.media.audiofx.Equalizer.getCenterFreq
+     */
+    fun getBandCenterFreq(band: Int): Int
+
+    /**
+     * Applies the configured audio effects to the [Playback] service.
+     *
+     * This function triggers the transfer of the configured audio effects to the [Playback] service for saving and
+     * applying them to the current audio playback.
+     */
+    fun apply()
+}

--- a/app/src/main/java/com/prime/media/impl/AudioFxViewModel.kt
+++ b/app/src/main/java/com/prime/media/impl/AudioFxViewModel.kt
@@ -1,0 +1,113 @@
+package com.prime.media.impl
+
+import android.content.ContentResolver
+import android.content.res.Resources
+import android.media.audiofx.Equalizer
+import android.media.audiofx.PresetReverb
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.prime.media.core.compose.Channel
+import com.prime.media.core.playback.Remote
+import com.prime.media.editor.TagEditor
+import com.prime.media.effects.AudioFx
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+private const val TAG = "AudioFxViewModel"
+
+private val Equalizer.bandLevels
+    get() = List(numberOfBands.toInt()) {
+        getBandLevel(it.toShort()).toFloat()
+    }
+
+// TODO: Handle the case for not supported.
+private val Equalizer.status
+    get() = when {
+        !hasControl() -> AudioFx.EFFECT_STATUS_NO_CONTROL
+        enabled -> AudioFx.EFFECT_STATUS_ENABLED
+        else -> AudioFx.EFFECT_STATUS_DISABLED
+    }
+
+@HiltViewModel
+class AudioFxViewModel @Inject constructor(
+    private val remote: Remote
+) : ViewModel(), AudioFx {
+
+    // TODO: Find proper way to get this property.
+    private val equalizer = runBlocking { remote.getEqualizer(2) }
+
+    private var _eqStatus by mutableIntStateOf(equalizer.status)
+    var _eqCurrentPreset: Int by mutableIntStateOf(equalizer.currentPreset.toInt())
+
+    override var isEqualizerEnabled: Boolean
+        get() = _eqStatus == AudioFx.EFFECT_STATUS_ENABLED
+        set(value) {
+            //TODO: Handle case when not supported.
+            _eqStatus = if (value) AudioFx.EFFECT_STATUS_ENABLED else AudioFx.EFFECT_STATUS_DISABLED
+            equalizer.enabled = value
+        }
+    override val eqPresets: List<String> =
+        List(equalizer.numberOfPresets.toInt()) {
+            equalizer.getPresetName(it.toShort())
+        }
+    override val eqNumberOfBands: Int = equalizer.numberOfBands.toInt()
+    override val eqNumPresets: Int = equalizer.numberOfPresets.toInt()
+    override var eqCurrentPreset: Int
+        get() = _eqCurrentPreset
+        set(value) {
+            _eqCurrentPreset = value
+            // only set preset when in range
+            if (value in 0 until equalizer.numberOfPresets)
+                equalizer.usePreset(value.toShort())
+            val levels = equalizer.bandLevels
+            levels.forEachIndexed { index, value ->
+                eqBandLevels[index] = equalizer.getBandLevel(index.toShort()).toFloat()
+            }
+        }
+
+    override val eqBandLevels =
+        mutableStateListOf<Float>().also {
+            it.addAll(equalizer.bandLevels)
+        }
+    override val eqBandLevelRange: ClosedFloatingPointRange<Float> =
+        equalizer.bandLevelRange.let { it[0].toFloat()..it[1].toFloat() }
+
+    override fun getBandFreqRange(band: Int): ClosedFloatingPointRange<Float> =
+        equalizer.getBandFreqRange(band.toShort()).let { it[0].toFloat()..it[1].toFloat() }
+
+    override fun getBandCenterFreq(band: Int): Int =
+        equalizer.getCenterFreq(band.toShort())
+
+    override fun setBandLevel(band: Int, level: Float) {
+        eqCurrentPreset = -1
+        equalizer.setBandLevel(band.toShort(), level.roundToInt().toShort())
+
+        /*repeat(eqNumberOfBands) { b ->
+            val value = level * if (b == band) 1.0f else 0.75f / abs(band - b) // distance.
+            equalizer.setBandLevel(band.toShort(), value.roundToInt().toShort())
+            eqBandLevels[b] = value
+        }*/
+    }
+
+    override fun apply() {
+        viewModelScope.launch {
+            // equalizer will be release by calling this
+            remote.setEqualizer(equalizer)
+        }
+    }
+
+    override fun onCleared() {
+        equalizer.release()
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/com/prime/media/impl/ConsoleViewModel.kt
+++ b/app/src/main/java/com/prime/media/impl/ConsoleViewModel.kt
@@ -174,10 +174,10 @@ class ConsoleViewModel @Inject constructor(
             // when state of playing.
             // FixMe: This event is triggered more often e.g., when track is changed.
             // may be add some more check.
-            Player.EVENT_IS_PLAYING_CHANGED -> {
-                playing = remote.isPlaying
+            Player.EVENT_PLAY_WHEN_READY_CHANGED -> {
+                playing = remote.playWhenReady
                 sleepAfterMills = UNINITIALIZED_SLEEP_TIME_MILLIS
-                if (remote.isPlaying)
+                if (remote.playWhenReady)
                     MainHandler.repeat(PROGRESS_TOKEN, 1000, call = onProgressUpdate)
                 else
                     MainHandler.remove(PROGRESS_TOKEN)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,4 +350,10 @@
     <!--======================         Playback speed Dialog        ======================      -->
     <string name="playback_speed_dialog_title">Playback Speed <sup><font color = "#ae1c27" size= "10"><b>Beta</b></font></sup></string>
     <string name="playback_speed_dialog_x_f">%1$.2f x</string>
+
+    <!--======================         Equalizer        ======================      -->
+    <string name="equalizer">Equalizer <sup><font color = "#ae1c27" size= "10"><b>Beta</b></font></sup></string>
+    <string name="apply">Apply</string>
+    <string name="equalizer_scr_abbr_db_suffix_d">%1$s dB</string>
+    <string name="equalizer_scr_abbr_hz_suffix_d">%1$s Hz</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [plugins]
-androidApplication = { id = "com.android.application", version = "8.2.0-beta04" }
+androidApplication = { id = "com.android.application", version = "8.2.0-beta05" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version = "1.9.10" }
 firebase = { id = "com.google.gms.google-services", version = "4.3.15" }
 hilt = { id = "com.google.dagger.hilt.android", version = "2.48"}


### PR DESCRIPTION
… fixed README.md issue

- Added a new screen for the Equalizer UI, which allows the user to adjust the equalizer parameters and presets.
- Added a new destination in the navigation graph for the AudioFx screen.
- Added Equalizer class in Playback.kt to control the equalizer effect on the audio session of the service. The equalizer is created with priority 0 and is released when the service is stopped. The equalizer configuration can be get or set by using the ACTION_EQUALIZER_CONFIG custom command with the corresponding extras: EXTRA_EQUALIZER_ENABLED and EXTRA_EQUALIZER_PROPERTIES.
- Renamed init() method to onRestoreSavedState() in PlaybackService.kt to avoid confusion with the init block.
- Fixed the issue where clicking on the README.md link in the GitHub release page would open the Play Store instead of the GitHub release page. Changed the link to point to the correct URL.
- Added methods for setting equalizer parameters in Remote.kt and updated the kDoc comments accordingly.

[FIX]: Resolved issues with album-art, Remote, Console, and Sleep timer
- Bumped the app, gradle version.
- Renamed onRestoreSavedState in service to init()
- Fix the bug causing the invalid/wrong album-art to load when playing audio through intent.
- Add method playWhenReady to Remote.
- Made Console depend on playWhenReady instead of isPlaying; this fixes the issue with animations when track transitions or some other issue occurs.
- Made the monitoring job in service depend on onPlayWhenReadyChanged instead of isPlaying; this fixes the issue causing playback to cancel sleep timer when isPlaying returns false because user seeked or track transitioned.

This commit fixes #30  issue on GitHub regarding support for the AudioFx Equalizer.