### PR TITLE
[Feature]: Added missing documentation and fixed various bugs.

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="AppInsightsSettings">
-    <option name="selectedTabId" value="Android Vitals" />
+    <option name="selectedTabId" value="Firebase Crashlytics" />
     <option name="tabSettings">
       <map>
         <entry key="Android Vitals">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,8 +28,8 @@ android {
         applicationId = "com.prime.player"
         minSdk = 27
         targetSdk = 34
-        versionCode = 56
-        versionName = "2.6.0"
+        versionCode = 57
+        versionName = "2.6.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }
         //Load secrets into BuildConfig

--- a/app/src/main/java/com/prime/media/console/Console.kt
+++ b/app/src/main/java/com/prime/media/console/Console.kt
@@ -97,6 +97,7 @@ import com.prime.media.core.compose.LocalSystemFacade
 import com.prime.media.core.compose.LottieAnimButton
 import com.prime.media.core.compose.LottieAnimation
 import com.prime.media.core.compose.marque
+import com.prime.media.core.compose.preference
 import com.prime.media.core.compose.shape.CompactDisk
 import com.prime.media.core.util.DateUtils
 import com.prime.media.darkShadowColor
@@ -338,8 +339,15 @@ private fun Vertical(
         )
 
         val controller = LocalNavController.current
+        // FixMe: State is not required here. implement to get value without state.
+        val useBuiltIn by preference(key = Settings.USE_IN_BUILT_AUDIO_FX)
         IconButton(
-            onClick = { controller.navigate(AudioFx.route) },
+            onClick = {
+                if (useBuiltIn)
+                    controller.navigate(AudioFx.route)
+                else
+                    facade.launchEqualizer(state.audioSessionId)
+            },
             imageVector = Icons.Outlined.Tune,
             contentDescription = null,
             modifier = Modifier.layoutID(Console.EQUALIZER),
@@ -467,16 +475,20 @@ private fun Vertical(
             content = {
                 val mills = state.sleepAfterMills
                 if (mills == -1L)
-                    return@IconButton Icon(imageVector = Icons.Outlined.Timer, contentDescription = null,  tint = onColor)
+                    return@IconButton Icon(
+                        imageVector = Icons.Outlined.Timer,
+                        contentDescription = null,
+                        tint = onColor
+                    )
                 Label(
-                    text = formatElapsedTime(mills/1000L),
+                    text = formatElapsedTime(mills / 1000L),
                     style = Material.typography.caption2,
                     fontWeight = FontWeight.Bold,
                     color = Material.colors.secondary
                 )
             }
         )
-        
+
         val shuffle = state.shuffle
         LottieAnimButton(
             id = R.raw.lt_shuffle_on_off,
@@ -489,7 +501,7 @@ private fun Vertical(
 
         val mode = state.repeatMode
         AnimatedIconButton(
-            id  = R.drawable.avd_repeat_more_one_all,
+            id = R.drawable.avd_repeat_more_one_all,
             onClick = { state.cycleRepeatMode();facade.launchReviewFlow(); },
             atEnd = mode == Player.REPEAT_MODE_ALL,
             modifier = Modifier.layoutID(Console.REPEAT),

--- a/app/src/main/java/com/prime/media/effects/AudioFx.kt
+++ b/app/src/main/java/com/prime/media/effects/AudioFx.kt
@@ -2,6 +2,7 @@
 
 package com.prime.media.effects
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
@@ -74,7 +75,6 @@ private fun TopBar(
     )
 }
 
-
 @Composable
 @NonRestartableComposable
 private fun BottomBar(
@@ -101,7 +101,6 @@ private fun BottomBar(
     }
 }
 
-
 @Composable
 private fun Equalizer(
     fx: AudioFx,
@@ -121,14 +120,14 @@ private fun Equalizer(
             CompositionLocalProvider(LocalTextStyle provides Material.typography.caption) {
                 Label(
                     text = stringResource(
-                        id = R.string.equalizer_scr_abbr_db_suffix_d,
+                        id = R.string.audio_fx_scr_abbr_db_suffix_d,
                         fx.eqBandLevelRange.endInclusive / 1000
                     )
                 )
-                Label(text = stringResource(id = R.string.equalizer_scr_abbr_db_suffix_d, 0))
+                Label(text = stringResource(id = R.string.audio_fx_scr_abbr_db_suffix_d, 0))
                 Label(
                     text = stringResource(
-                        id = R.string.equalizer_scr_abbr_db_suffix_d,
+                        id = R.string.audio_fx_scr_abbr_db_suffix_d,
                         fx.eqBandLevelRange.start / 1000
                     )
                 )
@@ -150,7 +149,7 @@ private fun Equalizer(
 
                 Label(
                     text = stringResource(
-                        id = R.string.equalizer_scr_abbr_hz_suffix_d,
+                        id = R.string.audio_fx_scr_abbr_hz_suffix_d,
                         fx.getBandCenterFreq(band) / 1000
                     ),
                     style = Material.typography.caption2
@@ -197,6 +196,9 @@ fun Preset(
 }
 
 
+private inline val AudioFx.isEqualizerReady
+    get() = stateOfEqualizer != AudioFx.EFFECT_STATUS_NOT_READY || stateOfEqualizer != AudioFx.EFFECT_STATUS_NOT_SUPPORTED
+
 @Composable
 @NonRestartableComposable
 fun AudioFx(
@@ -207,36 +209,33 @@ fun AudioFx(
             .clip(Material.shapes.small2)
             .background(Material.colors.surface)
             .fillMaxWidth()
+            .animateContentSize()
             .pointerInput(Unit) {}
     ) {
         TopBar(state.isEqualizerEnabled, onToggleState = { state.isEqualizerEnabled = it })
-        Row(
-            Modifier
-                .horizontalScroll(rememberScrollState())
-                .padding(horizontal = ContentPadding.normal, vertical = ContentPadding.medium)
-        ) {
-            val current = state.eqCurrentPreset
-            Preset(
-                label = "Custom",
-                onClick = { state.eqCurrentPreset = -1 },
-                selected = current == -1
-            )
-            state.eqPresets.forEachIndexed { index, s ->
-                Preset(
-                    label = s,
-                    onClick = { state.eqCurrentPreset = index },
-                    selected = current == index
-                )
+        if (state.isEqualizerReady) {
+            Row(
+                Modifier
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = ContentPadding.normal, vertical = ContentPadding.medium)
+            ) {
+                state.eqPresets.forEachIndexed { index, s ->
+                    val current = state.eqCurrentPreset
+                    Preset(
+                        label = s,
+                        onClick = { state.eqCurrentPreset = index },
+                        selected = current == index
+                    )
+                }
             }
+
+            Equalizer(
+                fx = state,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = ContentPadding.normal, vertical = ContentPadding.medium)
+            )
         }
-
-        Equalizer(
-            fx = state,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = ContentPadding.normal, vertical = ContentPadding.medium)
-        )
-
         val controller = LocalNavController.current
         BottomBar(
             onDismissRequest = {

--- a/app/src/main/java/com/prime/media/effects/ViewState.kt
+++ b/app/src/main/java/com/prime/media/effects/ViewState.kt
@@ -25,11 +25,51 @@ interface AudioFx {
          */
         fun direction() = route
 
-        const val EFFECT_STATUS_UNSUPPORTED = -1
+        /**
+         * Represents that the audio effect is not supported on the device.
+         * This means that the device or platform does not provide the capability
+         * to use the specific audio effect.
+         */
+        const val EFFECT_STATUS_NOT_SUPPORTED = -1
+
+        /**
+         * Represents that the audio effect is disabled.
+         * The effect is available on the device but is currently turned off.
+         */
         const val EFFECT_STATUS_DISABLED = 0
+
+        /**
+         * Represents that the audio effect is enabled and actively affecting the audio.
+         * The effect is currently active and applied to the audio stream.
+         */
         const val EFFECT_STATUS_ENABLED = 1
+
+        /**
+         * Represents that the audio effect does not have control over the audio.
+         * This state typically indicates that the effect cannot modify the audio stream
+         * due to various reasons, such as lack of permissions or conflicts with other effects.
+         */
         const val EFFECT_STATUS_NO_CONTROL = 2
+
+        /**
+         * Represents that the audio effect is not ready for use.
+         * This state indicates that the effect is not yet prepared to process audio data.
+         * It may require initialization or configuration before it can be enabled.
+         */
+        const val EFFECT_STATUS_NOT_READY = 3
     }
+
+    /**
+     * Represents the state of the equalizer, which can be one of the following values:
+     * - [EFFECT_STATUS_NOT_SUPPORTED]: The equalizer is not supported on the device.
+     * - [EFFECT_STATUS_DISABLED]: The equalizer is currently disabled.
+     * - [EFFECT_STATUS_ENABLED]: The equalizer is currently enabled and actively affecting the audio.
+     * - [EFFECT_STATUS_NO_CONTROL]: The equalizer does not have control over the audio.
+     * - [EFFECT_STATUS_NOT_READY]: The equalizer is not ready for use and requires initialization or configuration.
+     *
+     * You can enable or disable the equalizer using the [isEqualizerEnabled] property.
+     */
+    val stateOfEqualizer: Int
 
     /**
      * Property for enabling or disabling the Equalizer.
@@ -39,7 +79,7 @@ interface AudioFx {
     /**
      * List of supported Equalizer presets.
      */
-    val eqPresets: List<String>
+    val eqPresets: Array<String>
 
     /**
      * Get the number of supported bands in the Equalizer.

--- a/app/src/main/java/com/prime/media/impl/SettingsViewModel.kt
+++ b/app/src/main/java/com/prime/media/impl/SettingsViewModel.kt
@@ -102,8 +102,8 @@ class SettingsViewModel @Inject constructor(
     override val fetchArtworkFromMS: Preference<Boolean> by with(preferences) {
         preferences[Settings.USE_LEGACY_ARTWORK_METHOD].map {
             Preference(
-                title = Text(R.string.pref_fetch_artwork_from_mediastore),
-                summery = Text(R.string.pref_fetch_artwork_from_mediastore_summery),
+                title = Text(R.string.pref_fetch_artwork_from_media_store),
+                summery = Text(R.string.pref_fetch_artwork_from_media_store_summery),
                 value = it
             )
         }.asComposeState()
@@ -141,6 +141,24 @@ class SettingsViewModel @Inject constructor(
             Preference(
                 title = Text(R.string.pref_crossfade_time),
                 summery = Text(R.string.pref_crossfade_time_summery),
+                value = it
+            )
+        }.asComposeState()
+    }
+    override val closePlaybackWhenTaskRemoved by with(preferences) {
+        preferences[Settings.CLOSE_WHEN_TASK_REMOVED].map {
+            Preference(
+                title = Text(R.string.pref_stop_playback_when_task_removed),
+                summery = Text(R.string.pref_stop_playback_when_task_removed_summery),
+                value = it
+            )
+        }.asComposeState()
+    }
+    override val useInbuiltAudioFx by with(preferences) {
+        preferences[Settings.USE_IN_BUILT_AUDIO_FX].map {
+            Preference(
+                title = Text(R.string.pref_use_inbuilt_audio_effects),
+                summery = Text(R.string.pref_use_inbuilt_audio_effects_summery),
                 value = it
             )
         }.asComposeState()

--- a/app/src/main/java/com/prime/media/settings/Settings.kt
+++ b/app/src/main/java/com/prime/media/settings/Settings.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Camera
 import androidx.compose.material.icons.outlined.DataObject
 import androidx.compose.material.icons.outlined.Feedback
+import androidx.compose.material.icons.outlined.HideSource
 import androidx.compose.material.icons.outlined.Recycling
 import androidx.compose.material.icons.outlined.ReplyAll
 import androidx.compose.material.icons.outlined.Share
@@ -41,6 +42,7 @@ import androidx.compose.material.icons.outlined.Star
 import androidx.compose.material.icons.outlined.Straighten
 import androidx.compose.material.icons.outlined.SupportAgent
 import androidx.compose.material.icons.outlined.TouchApp
+import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.NonRestartableComposable
@@ -328,6 +330,28 @@ private inline fun General(
         valueRange = 50f..200f,
         preview = "${maxRecentSize.value} files",
         steps = 5
+    )
+
+    val useInbuiltAudioFx = state.useInbuiltAudioFx
+    SwitchPreference(
+        title = stringResource(value = useInbuiltAudioFx.title),
+        checked = useInbuiltAudioFx.value,
+        summery = stringResource(value = useInbuiltAudioFx.summery),
+        onCheckedChange = {
+            state.set(Settings.USE_IN_BUILT_AUDIO_FX, it)
+        },
+        icon = Icons.Outlined.Tune
+    )
+
+    val closePlaybackWhenTaskRemoved = state.closePlaybackWhenTaskRemoved
+    SwitchPreference(
+        title = stringResource(value = closePlaybackWhenTaskRemoved.title),
+        checked = closePlaybackWhenTaskRemoved.value,
+        summery = stringResource(value = closePlaybackWhenTaskRemoved.summery),
+        onCheckedChange = {
+            state.set(Settings.CLOSE_WHEN_TASK_REMOVED, it)
+        },
+        icon = Icons.Outlined.HideSource
     )
 }
 

--- a/app/src/main/java/com/prime/media/settings/ViewState.kt
+++ b/app/src/main/java/com/prime/media/settings/ViewState.kt
@@ -117,6 +117,20 @@ interface Settings : Blacklist {
         val BLACKLISTED_FILES = stringSetPreferenceKey(PREFIX + "_blacklisted_files")
         val GAPLESS_PLAYBACK = booleanPreferenceKey(PREFIX + "_gap_less_playback")
         val CROSS_FADE_DURATION_SECS = intPreferenceKey(PREFIX + "_cross_fade_tracks_durations")
+
+        /**
+         * Determines whether playback should automatically stop when the associated task is removed.
+         * If set to true, the playback will be closed when the task is removed.
+         * If set to false, the playback will continue even if the task is removed.
+         */
+        val CLOSE_WHEN_TASK_REMOVED = Playback.PREF_KEY_CLOSE_WHEN_REMOVED
+
+        /**
+         * Indicates whether to use the built-in audio effects or third-party audio effects.
+         * If set to true, the application will use the built-in audio effects.
+         * If set to false, third-party audio effects may be used, if available.
+         */
+        val USE_IN_BUILT_AUDIO_FX = booleanPreferenceKey(PREFIX + "_use_in_built_audio_fx", true)
     }
 
     val darkUiMode: Preference<NightMode>
@@ -130,6 +144,8 @@ interface Settings : Blacklist {
     val excludedFiles: Preference<Set<String>?>
     val gaplessPlayback: Preference<Boolean>
     val crossfadeTime: Preference<Int>
+    val closePlaybackWhenTaskRemoved: Preference<Boolean>
+    val useInbuiltAudioFx: Preference<Boolean>
 
     fun <S, O> set(key: Key<S, O>, value: O)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
      Naming convention for string resources:
      - The string can be styled following the rules of styling without CDATA, as the toolkit does not support CDATA.
      - The string resources should be named as follows:
@@ -10,8 +9,7 @@
        5. The snackbar message should have this structure: Title\n bold + experimental + message.
    -->
 <!--Some common variables-->
-<!DOCTYPE resources [<!ENTITY appname "Audiofy"><!ENTITY author "Zakir Sheikh"><!ENTITY version_name "0.0.1-dev">]>
-<!--The string resources should follow the above rules strictly-->
+<!DOCTYPE resources [<!ENTITY appname "Audiofy"><!ENTITY author "Zakir Sheikh"><!ENTITY version_name "0.0.1-dev"> <!ENTITY beta "<sup><font color = '#ae1c27' size= '10'><b>Beta</b></font></sup>">]><!--The string resources should follow the above rules strictly-->
 <resources>
     <string name="app_name">&appname;</string>
     <!--The name of the app icon in launcher.-->
@@ -87,6 +85,7 @@
     <string name="year">Year</string>
     <string name="disk_number">Disk number</string>
     <string name="property">property</string>
+    <string name="apply">Apply</string>
     <string name="track_number">Track number</string>
     <string name="genre">Genre</string>
     <string name="composer">Composer</string>
@@ -230,11 +229,22 @@
     <!--Recent Playlist Size-->
     <string name="pref_recent_playlist_size">Recent playlist size</string>
     <string name="pref_recent_playlist_size_summery">
-        "Set the maximum number of tracks that should be stored in the playlist history."
+        Set the maximum number of tracks that should be stored in the playlist history.
     </string>
+
+    <!--Stop Playback when app is removed from recents.-->
+    <string name="pref_stop_playback_when_task_removed">Stop Playback</string>
+    <string name="pref_stop_playback_when_task_removed_summery">Stop playback service when app is
+        removed from recents.
+    </string>
+
+    <string name="pref_use_inbuilt_audio_effects">Audio Effects</string>
+    <string name="pref_use_inbuilt_audio_effects_summery">Switch between in-built or 3rd party
+        audio effects.\n<i>Turn Off in-built effects manually if using 3rd party app.</i></string>
+
     <!--Fetch_artwork_from_MediaStore-->
-    <string name="pref_fetch_artwork_from_mediastore">Fetch artwork from MediaStore</string>
-    <string name="pref_fetch_artwork_from_mediastore_summery">
+    <string name="pref_fetch_artwork_from_media_store">Fetch artwork from MediaStore</string>
+    <string name="pref_fetch_artwork_from_media_store_summery">
          Faster artwork loading times, but there is a possibility of displaying incorrect artwork.\n
         Changing this setting requires <i>restarting</i> the app.
     </string>
@@ -321,7 +331,7 @@
 
     <!--============================          TagEditor     ==================================      -->
     <string name="overwrite">Overwrite</string>
-    <string name="tag_editor_scr_pro_title">Tag Editor <sup><font color = "#00a300" size= "11">Pro</font></sup></string>
+    <string name="tag_editor_scr_pro_title">Tag Editor <sup><font color="#00a300" size="11">Pro</font></sup></string>
     <string name="tag_editor_scr_title">Tag Editor</string>
     <string name="tag_editor_scr_extra_immutable_info_ssss"><small>Channel</small> <b>\n%1s\n</b> Bitrate <b>\n%1s  kbps</b>\n Duration \n <b>\n%1s\n</b> Sample rate <b>\n%1s Hz\n</b></string>
     <string name="msg_tag_editor_reset_warning"><b>Warning</b>\nReset will result in data loss. Are you sure?</string>
@@ -335,7 +345,7 @@
     </string>
     <string name="tag_editor_screen_buy_now_action">Get Tag Editor Pro</string>
     <string name="tag_editor_property_placeholder">Tap here to enter text</string>
-    <string name="tag_editor_web_address_prefix"><font color = "#00a300">http://</font></string>
+    <string name="tag_editor_web_address_prefix"><font color="#00a300">http://</font></string>
     <string name="lyrics">Lyrics</string>
     <string name="msg_tag_editor_error_s"><b>Error</b> \n%1s</string>
     <string name="tag_editor_lyrics_placeholder">
@@ -344,16 +354,30 @@
         2. Un-Synchronized Text.</string>
 
     <!--======================         Sleep Timer Dialog        ======================      -->
-    <string name="sleep_timer_dialog_title">Sleep Timer <sup><font color = "#ae1c27" size= "10"><b>Beta</b></font></sup></string>
+    <string name="sleep_timer_dialog_title">Sleep Timer &beta;</string>
     <string name="sleep_timer_dialog_minute_s">%1$s min</string>
 
     <!--======================         Playback speed Dialog        ======================      -->
-    <string name="playback_speed_dialog_title">Playback Speed <sup><font color = "#ae1c27" size= "10"><b>Beta</b></font></sup></string>
+    <string name="playback_speed_dialog_title">Playback Speed &beta;</string>
     <string name="playback_speed_dialog_x_f">%1$.2f x</string>
 
-    <!--======================         Equalizer        ======================      -->
-    <string name="equalizer">Equalizer <sup><font color = "#ae1c27" size= "10"><b>Beta</b></font></sup></string>
-    <string name="apply">Apply</string>
-    <string name="equalizer_scr_abbr_db_suffix_d">%1$s dB</string>
-    <string name="equalizer_scr_abbr_hz_suffix_d">%1$s Hz</string>
+    <!--======================         AudioFx        ======================      -->
+    <string name="audio_fx_scr_ttile">@string/equalizer</string>
+    <string name="equalizer">Equalizer &beta;</string>
+    <string name="audio_fx_scr_abbr_db_suffix_d">%1$s dB</string>
+    <string name="audio_fx_scr_abbr_hz_suffix_d">%1$s Hz</string>
+    <!-- The names of presets supported by the equalizer class of android. 0th represents Custom.-->
+    <array name="audio_fx_scr_equalizer_presets">
+        <item>Custom</item>
+        <item>Normal</item>
+        <item>Classical</item>
+        <item>Dance</item>
+        <item>Flat</item>
+        <item>Folk</item>
+        <item>Heavy Metal</item>
+        <item>Hip Hop</item>
+        <item>Jazz</item>
+        <item>Pop</item>
+        <item>Rock</item>
+    </array>
 </resources>


### PR DESCRIPTION
- Added two more preferences: PREF_KEY_CLOSE_WHEN_REMOVED and USE_IN_BUILT_AUDIO_FX
- PREF_KEY_CLOSE_WHEN_REMOVED allows the user to choose whether to stop the playback service when the app is removed from the recent tasks list
- USE_IN_BUILT_AUDIO_FX allows the user to choose whether to use the in-built audio effects or a third-party app for sound enhancement.

[FIX]: Fixed crash in android Equalizer by delaying effect engine initialization

- The crash was occurring because the effect engine was throwing an error if it was initialized immediately after launching the app. This error was fixed by moving the Equalizer initialization to the Remote.getEqualizerOrRetry function, which handles the error gracefully and retries the initialization with an increasing delay of 100ms * retry count.